### PR TITLE
Fix typo causing unresolved symbol in intermediary step (Part 7)

### DIFF
--- a/tutorial/clojure/7_pick_a_handler_based_on_route.html
+++ b/tutorial/clojure/7_pick_a_handler_based_on_route.html
@@ -78,7 +78,7 @@
 
 (defn routes
   [system]
-  [["/"        {:get {:handler handler}}]
+  [["/"        {:get {:handler hello-handler}}]
    ["/goodbye" {:get {:handler goodbye-handler}}]])</span></pre>
         </code>
     </li>


### PR DESCRIPTION
Fixing the following issue: In Part 7 the second intermediary step contains a reference the old handler name "handler" (from Part 4) instead of the new "hello-handler" which will cause an unresolved symbol error.