### PR TITLE
Fix missing namespace in 1_create_a_project.html

### DIFF
--- a/tutorial/clojure/1_create_a_project.html
+++ b/tutorial/clojure/1_create_a_project.html
@@ -130,7 +130,7 @@ help:
     just --list
                 
 run:
-    clojure -M -m main</pre
+    clojure -M -m example.main</pre
           >
         </code>
       </li>
@@ -143,7 +143,7 @@ run:
         <code>
           <pre>
 $ just run
-clojure -M -m main
+clojure -M -m example.main
 Hello, world
           </pre>
         </code>


### PR DESCRIPTION
In the first part of the tutorial, the namespace is missing from the `Justfile`.