### PR TITLE
Update 1_create_a_project.html

### DIFF
--- a/site/tutorial/clojure/1_create_a_project.html
+++ b/site/tutorial/clojure/1_create_a_project.html
@@ -196,7 +196,7 @@ You can check using the <code>tree</code>
 command.
 <code>
       <pre>
-src/
+src/example/
   main.clj
 deps.edn
 Justfile</pre


### PR DESCRIPTION
Fixed a small typo where the namespace was left out of the project structure description.