### PR TITLE
Fix typo

### DIFF
--- a/site/tutorial/clojure/8_log_information.html
+++ b/site/tutorial/clojure/8_log_information.html
@@ -66,7 +66,7 @@
                 your deps.edn</a></h2>
             <p>This is your "logging implementation" - the thing that determines how logs are actually emitted.</p>
             <p><code>slf4j-simple</code> is, as the name suggests, the simplest possible implementation. It outputs
-                all logs to standard error. If that is not enough for you then you can pick something else.</p>
+                all logs to standard output (STDOUT). If that is not enough for you then you can pick something else.</p>
             <p>Once you add this you should notice that you no longer get warnings when you start up. In addition,
                 you will start to see logs from the underlying server libraries.</p>
             <code><pre>{:paths ["src"]


### PR DESCRIPTION
It looks like by default logs are written to standard output (STDOUT)