### PR TITLE
Add id to form input to improve accessibility

### DIFF
--- a/site/tutorial/clojure/19_display_forms.html
+++ b/site/tutorial/clojure/19_display_forms.html
@@ -69,7 +69,7 @@
                    [:form {:method "post"
                            :action "/cave/create"}
                     [:label {:for "description"} "Description"]
-                    [:input {:name "description" :type "text"}]
+                    [:input {:name "description" :id "description" :type "text"}]
                     [:input {:type "submit"}]]]]))})
 
 (defn routes


### PR DESCRIPTION
Having id in the form input makes its label clickable - puts cursor inside the input, which improves accessibility. 
This is not necessary, but may be worth adding it here as a general good practice.