### PR TITLE
Fix type formatting

### DIFF
--- a/site/tutorial/clojure/21_process_form_submits.html
+++ b/site/tutorial/clojure/21_process_form_submits.html
@@ -94,9 +94,9 @@
   (:require [example.middleware :as middleware]
             <span style="font-weight: bold;">[example.system :as-alias system]</span>
             [hiccup2.core :as hiccup]
-            <span style="font-weight: bold;">[next.jdbc :as jdbc]
+            <span style="font-weight: bold;">[next.jdbc :as jdbc]</span>
             [ring.util.anti-forgery :as anti-forgery]
-            [ring.util.response :as response]</span>))
+            <span style="font-weight: bold;">[ring.util.response :as response]</span>))
 
 (defn cave-create-handler
   [{::system/keys [db]} request]


### PR DESCRIPTION
Remove bold from '[ring.util.anti-forgery :as anti-forgery]' as it was added in the previous step.